### PR TITLE
feat: add Codeup (阿里云效) issue source mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 tests/*.log
 tests/*.tmp
 .claude/
-.autoresearch/workflows/*/terminal.log
+.autoresearch/workflows/*/terminal.log__pycache__/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![宣传视频](docs/autoresearch-promo-cn.gif)
 
-基于 [karpathy/autoresearch](https://github.com/karpathy/autoresearch) 思想实现的通用的全自动化开发工具。支持 **GitHub Issue**、**本地 Issue** 和**百度 iCafe** 三种模式，适用于任意 Git 项目（Go、Node.js、Python、Rust、Java 等）。
+基于 [karpathy/autoresearch](https://github.com/karpathy/autoresearch) 思想实现的通用的全自动化开发工具。支持 **GitHub Issue**、**本地 Issue** 和**百度 iCafe** 四种模式，适用于任意 Git 项目（Go、Node.js、Python、Rust、Java 等）。
 
 使用 autoresearch 实现本项目 Issue#2：
 [![asciicast](https://asciinema.org/a/KdHGFHK6pcelUdPg.svg)](https://asciinema.org/a/KdHGFHK6pcelUdPg)
@@ -21,6 +21,7 @@
 - [工作流程](#工作流程)
 - [本地 Issue 模式](#本地-issue-模式)
 - [百度 iCafe 模式](#百度-icafe-模式)
+- [阿里云效 Codeup 模式](#阿里云效-codeup-模式)
 - [工具配置](#工具配置)
 - [与 ralph 对比](#与-ralph-对比)
 
@@ -55,6 +56,9 @@ autoresearch/run.sh --issues-dir=.autoresearch/issues 8
 
 # 百度 iCafe 模式（卡片 #22210）
 autoresearch/run.sh --issue-source=baidu --space=cloud-iCafe 22210
+
+# 阿里云效 Codeup 模式（Issue #42）
+autoresearch/run.sh --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456 42
 ```
 
 ## 前置条件
@@ -65,6 +69,7 @@ autoresearch/run.sh --issue-source=baidu --space=cloud-iCafe 22210
 gh auth status          # GitHub CLI（仅 GitHub 模式需要）
 icafe-cli whoami        # iCafe CLI（仅百度模式需要）
 icode-cli whoami        # iCode CLI（仅百度模式需要）
+curl --version          # 阿里云效 Codeup 模式需要 curl
 which claude            # Claude Code CLI
 which codex             # OpenAI Codex CLI
 which opencode          # OpenCode CLI
@@ -82,7 +87,7 @@ which opencode          # OpenCode CLI
 
 | 组件 | 说明 |
 |------|------|
-| **GitHub Issue / 本地 Issue / 百度 iCafe** | 触发输入 |
+| **GitHub Issue / 本地 Issue / 百度 iCafe / 阿里云效 Codeup** | 触发输入 |
 | **run.sh** | 核心运行器 |
 | **Claude / Codex / OpenCode** | 三个 Agent 轮转审核 |
 | **Score ≥ 85?** | 评分门控 |
@@ -375,6 +380,71 @@ iCafe 卡片 → Agent 实现 → 轮转审核+修复 → icode-cli push_cr → 
 | `agents/*.md` | Agent 提示词模板 |
 | `tests/test_agent_logic.sh` | agent 选择与顺序逻辑测试 |
 
+
+---
+
+## 阿里云效 Codeup 模式
+
+阿里云效 Codeup 模式使用 [Codeup](https://codeup.aliyun.com/)（代码托管）替代 GitHub Issue/PR 流程，适合使用阿里云效的企业项目。
+
+### 前置条件
+
+```bash
+# 需要 Codeup Access Token
+# 在 Codeup 控制台 -> 设置 -> Access Token 中创建
+export CODEUP_TOKEN=your_token_here
+
+# 需要组织 ID 和仓库 ID
+# 在 Codeup 项目设置页面可以看到
+export CODEUP_ORG_ID=your_org_id
+export CODEUP_REPO_ID=your_repo_id
+```
+
+### 快速开始
+
+```bash
+# 显式指定 codeup 模式
+./run.sh --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456 42
+
+# 使用环境变量
+export CODEUP_TOKEN=xxx
+export CODEUP_ORG_ID=123
+export CODEUP_REPO_ID=456
+./run.sh --issue-source=codeup 42
+
+# 指定 MR 目标分支
+./run.sh --issue-source=codeup --codeup-branch=develop 42
+
+# 批量处理所有未关闭的 Issues
+./run_all.sh --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456
+```
+
+### 工作流程
+
+```
+Codeup Issue -> Agent 实现 -> 轮转审核+修复 -> 创建 MR -> 合入 -> 关闭 Issue
+```
+
+与 GitHub 模式的主要区别：
+
+| 步骤 | GitHub 模式 | 阿里云效 Codeup 模式 |
+|------|------------|---------------------|
+| 获取 Issue | `gh issue view` | Codeup REST API |
+| 创建 PR | `gh pr create` | Codeup REST API (Create MR) |
+| 合并 | `gh pr merge` | Codeup REST API (Merge MR) |
+| 关闭 Issue | `gh issue close` | Codeup REST API (Close Issue) |
+| 评论 | `gh issue comment` | Codeup REST API (Add Note) |
+
+### 命令行参数
+
+| 参数 | 说明 |
+|------|------|
+| `--issue-source=codeup` | 指定阿里云效 Codeup 模式 |
+| `--codeup-token=<token>` | Codeup Access Token（也可用 `CODEUP_TOKEN` 环境变量） |
+| `--codeup-org=<org_id>` | Codeup 组织 ID（也可用 `CODEUP_ORG_ID` 环境变量） |
+| `--codeup-repo=<repo_id>` | Codeup 仓库 ID（也可用 `CODEUP_REPO_ID` 环境变量） |
+| `--codeup-branch=<name>` | Codeup MR 目标分支（默认自动检测） |
+
 ---
 
 ## 与 ralph 对比
@@ -398,7 +468,7 @@ iCafe 卡片 → Agent 实现 → 轮转审核+修复 → icode-cli push_cr → 
 **autoresearch 优势：**
 - 双轨质量门禁覆盖更广
 - 多 Agent 交叉审核提供不同视角
-- GitHub 端到端自动化闭环，也支持本地项目和百度 iCafe/iCode 运行
+- GitHub 端到端自动化闭环，也支持本地项目、百度 iCafe/iCode 和阿里云效 Codeup 运行
 - 上下文溢出自动交接
 - Continue 模式支持中断恢复
 

--- a/codeup_cli.py
+++ b/codeup_cli.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""
+Codeup CLI — Alibaba Cloud Codeup operations via SDK.
+
+Replaces the GitLab-compatible REST API calls that don't work with Codeup.
+Used by autoresearch's run.sh and run_all.sh for Codeup mode.
+
+Environment variables:
+  CODEUP_AK_ID      Alibaba Cloud Access Key ID (required)
+  CODEUP_AK_SECRET  Alibaba Cloud Access Key Secret (required)
+  CODEUP_ORG_ID     Codeup Organization ID (required)
+
+Usage:
+  python3 codeup_cli.py get_issue <workitem_identifier>
+  python3 codeup_cli.py list_issues [--state=opened|closed|all] [--page=N] [--per-page=N]
+  python3 codeup_cli.py create_mr <repo_id> <source_branch> <target_branch> <title> <description>
+  python3 codeup_cli.py merge_mr <repo_id> <mr_iid>
+  python3 codeup_cli.py get_mr <repo_id> <mr_iid>
+  python3 codeup_cli.py list_mrs <repo_id> [--state=opened|closed|merged|all] [--page=N]
+  python3 codeup_cli.py close_issue <workitem_identifier>
+  python3 codeup_cli.py add_comment <workitem_identifier> <body>
+  python3 codeup_cli.py get_workitem_status <workitem_identifier>
+"""
+
+import json
+import os
+import sys
+
+from alibabacloud_devops20210625.client import Client
+from alibabacloud_devops20210625 import models
+from alibabacloud_tea_openapi import models as open_api_models
+
+
+def get_client():
+    """Create and return an authenticated Codeup SDK client."""
+    ak_id = os.environ.get("CODEUP_AK_ID")
+    ak_secret = os.environ.get("CODEUP_AK_SECRET")
+    if not ak_id or not ak_secret:
+        print(json.dumps({"error": "CODEUP_AK_ID and CODEUP_AK_SECRET required"}))
+        sys.exit(1)
+
+    config = open_api_models.Config(
+        access_key_id=ak_id,
+        access_key_secret=ak_secret,
+        endpoint="devops.cn-hangzhou.aliyuncs.com",
+    )
+    return Client(config)
+
+
+def get_org_id():
+    org_id = os.environ.get("CODEUP_ORG_ID")
+    if not org_id:
+        print(json.dumps({"error": "CODEUP_ORG_ID required"}))
+        sys.exit(1)
+    return org_id
+
+
+def resolve_workitem_id(client, org_id, identifier):
+    """
+    Resolve a work item identifier (like ISWB-8 or internal ID) to the
+    form needed by the SDK. Both serial_number and internal identifier
+    work directly with get_work_item_info.
+    """
+    return str(identifier)
+
+
+def _resolve_internal_id(client, org_id, identifier):
+    """
+    Resolve to the internal workitem identifier needed by comment/status APIs.
+    get_work_item_info works with both serial_number and internal ID,
+    but comment/close APIs require the internal identifier.
+    """
+    try:
+        response = client.get_work_item_info(org_id, str(identifier))
+        return response.body.workitem.identifier
+    except Exception:
+        return str(identifier)
+
+
+def cmd_get_issue(args):
+    """Get work item info. Outputs JSON compatible with autoresearch."""
+    if len(args) < 1:
+        print(json.dumps({"error": "usage: get_issue <workitem_identifier>"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    workitem_id = resolve_workitem_id(client, org_id, args[0])
+
+    try:
+        response = client.get_work_item_info(org_id, workitem_id)
+        wi = response.body.workitem
+
+        # Map to GitLab Issue-like format for autoresearch compatibility
+        result = {
+            "title": wi.subject or "",
+            "description": wi.document or "",
+            "state": _map_status(wi.status, wi.logical_status),
+            "labels": wi.tag or [],
+            "serial_number": wi.serial_number or "",
+            "identifier": wi.identifier or "",
+            "category": wi.category_identifier or "",
+            "assignee": wi.assigned_to or "",
+            "created_at": wi.gmt_create,
+            "updated_at": wi.gmt_modified,
+        }
+        print(json.dumps(result, ensure_ascii=False))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+def cmd_list_issues(args):
+    """List work items (mapped from Issues)."""
+    client = get_client()
+    org_id = get_org_id()
+
+    state_filter = "opened"
+    page = 1
+    per_page = 20
+
+    i = 0
+    while i < len(args):
+        if args[i] == "--state" and i + 1 < len(args):
+            state_filter = args[i + 1]
+            i += 2
+        elif args[i].startswith("--state="):
+            state_filter = args[i].split("=", 1)[1]
+            i += 1
+        elif args[i] == "--page" and i + 1 < len(args):
+            page = int(args[i + 1])
+            i += 2
+        elif args[i].startswith("--page="):
+            page = int(args[i].split("=", 1)[1])
+            i += 1
+        elif args[i] == "--per-page" and i + 1 < len(args):
+            per_page = int(args[i + 1])
+            i += 2
+        elif args[i].startswith("--per-page="):
+            per_page = int(args[i].split("=", 1)[1])
+            i += 1
+        else:
+            i += 1
+
+    # List across all categories
+    all_items = []
+    for cat in ["Task", "Bug", "Req"]:
+        try:
+            request = models.ListWorkitemsRequest(
+                category=cat,
+                page=page,
+                page_size=per_page,
+            )
+            response = client.list_workitems(org_id, request)
+            if response.body.workitems:
+                all_items.extend(response.body.workitems)
+        except Exception:
+            pass
+
+    # Filter by state
+    results = []
+    for wi in all_items:
+        status = _map_status(wi.status, getattr(wi, "logical_status", None))
+        if state_filter == "all" or status == state_filter:
+            results.append({
+                "iid": wi.serial_number or "",
+                "identifier": wi.identifier or "",
+                "title": wi.subject or "",
+                "state": status,
+                "labels": wi.tag if hasattr(wi, "tag") else [],
+                "category": wi.category_identifier if hasattr(wi, "category_identifier") else "",
+            })
+
+    print(json.dumps(results, ensure_ascii=False))
+
+
+def _map_status(status_name, logical_status):
+    """Map Codeup workitem status to GitLab Issue state."""
+    if logical_status:
+        ls = logical_status.lower()
+        if "closed" in ls or "done" in ls or "resolved" in ls:
+            return "closed"
+        if "open" in ls or "processing" in ls or "reopen" in ls:
+            return "opened"
+    if status_name:
+        sn = status_name.lower()
+        if "关闭" in sn or "完成" in sn or "已解决" in sn:
+            return "closed"
+        if "打开" in sn or "处理中" in sn or "待处理" in sn:
+            return "opened"
+    return "opened"
+
+
+def cmd_create_mr(args):
+    """Create a Merge Request."""
+    if len(args) < 5:
+        print(json.dumps({"error": "usage: create_mr <repo_id> <source_branch> <target_branch> <title> <description>"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    repo_id = args[0]
+    source_branch = args[1]
+    target_branch = args[2]
+    title = args[3]
+    description = args[4]
+
+    try:
+        request = models.CreateMergeRequestRequest(
+            organization_id=org_id,
+            source_branch=source_branch,
+            target_branch=target_branch,
+            title=title,
+            description=description,
+            source_project_id=int(repo_id),
+            target_project_id=int(repo_id),
+        )
+        response = client.create_merge_request(repo_id, request)
+        mr = response.body.result
+        result = {
+            "iid": mr.local_id if hasattr(mr, "local_id") else None,
+            "id": mr.id if hasattr(mr, "id") else None,
+            "title": mr.title if hasattr(mr, "title") else title,
+            "state": mr.state if hasattr(mr, "state") else "opened",
+            "source_branch": source_branch,
+            "target_branch": target_branch,
+            "web_url": mr.web_url if hasattr(mr, "web_url") else "",
+        }
+        print(json.dumps(result, ensure_ascii=False))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+def cmd_merge_mr(args):
+    """Merge a Merge Request."""
+    if len(args) < 2:
+        print(json.dumps({"error": "usage: merge_mr <repo_id> <mr_iid>"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    repo_id = args[0]
+    mr_iid = args[1]
+
+    try:
+        request = models.MergeMergeRequestRequest(
+            organization_id=org_id,
+            merge_message=f"Merged by autoresearch",
+            remove_source_branch=True,
+        )
+        response = client.merge_merge_request(repo_id, mr_iid, request)
+        result = {
+            "state": "merged",
+            "iid": mr_iid,
+            "success": response.body.success if hasattr(response.body, "success") else True,
+        }
+        print(json.dumps(result))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+def cmd_get_mr(args):
+    """Get MR info."""
+    if len(args) < 2:
+        print(json.dumps({"error": "usage: get_mr <repo_id> <mr_iid>"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    repo_id = args[0]
+    mr_iid = args[1]
+
+    try:
+        request = models.GetMergeRequestRequest(organization_id=org_id)
+        response = client.get_merge_request(repo_id, mr_iid, request)
+        mr = response.body.result
+        result = {
+            "iid": mr.local_id if hasattr(mr, "local_id") else mr_iid,
+            "title": mr.title if hasattr(mr, "title") else "",
+            "state": mr.state if hasattr(mr, "state") else "",
+            "source_branch": mr.source_branch if hasattr(mr, "source_branch") else "",
+            "target_branch": mr.target_branch if hasattr(mr, "target_branch") else "",
+            "web_url": mr.web_url if hasattr(mr, "web_url") else "",
+        }
+        print(json.dumps(result, ensure_ascii=False))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+def cmd_list_mrs(args):
+    """List Merge Requests."""
+    if len(args) < 1:
+        print(json.dumps({"error": "usage: list_mrs <repo_id> [--state=opened|merged|closed|all]"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    repo_id = args[0]
+    state = "opened"
+
+    i = 1
+    while i < len(args):
+        if args[i].startswith("--state="):
+            state = args[i].split("=", 1)[1]
+            i += 1
+        elif args[i] == "--state" and i + 1 < len(args):
+            state = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    try:
+        request = models.ListMergeRequestsRequest(
+            organization_id=org_id,
+            project_ids=repo_id,
+            state=state,
+            page=1,
+            page_size=20,
+        )
+        response = client.list_merge_requests(request)
+        results = []
+        if hasattr(response.body, "result") and response.body.result:
+            for mr in response.body.result:
+                results.append({
+                    "iid": mr.local_id if hasattr(mr, "local_id") else None,
+                    "title": mr.title if hasattr(mr, "title") else "",
+                    "state": mr.state if hasattr(mr, "state") else "",
+                    "source_branch": mr.source_branch if hasattr(mr, "source_branch") else "",
+                    "target_branch": mr.target_branch if hasattr(mr, "target_branch") else "",
+                })
+        print(json.dumps(results, ensure_ascii=False))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+def cmd_close_issue(args):
+    """Close a work item (update status to closed)."""
+    if len(args) < 1:
+        print(json.dumps({"error": "usage: close_issue <workitem_identifier>"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    # Resolve to internal identifier (serial_number won't work for workflow APIs)
+    workitem_id = _resolve_internal_id(client, org_id, args[0])
+
+    try:
+        # Get current workflow info to find the "close" action
+        # First, get workitem info to find status
+        wi_response = client.get_work_item_info(org_id, workitem_id)
+        wi = wi_response.body.workitem
+
+        # Get workflow to find close action
+        wf_request = models.GetWorkItemWorkFlowInfoRequest()
+        wf_response = client.get_work_item_work_flow_info(org_id, workitem_id, wf_request)
+
+        # Find the close/resolve action
+        close_action = None
+        if wf_response.body.workflow and wf_response.body.workflow.workflow_actions:
+            for action in wf_response.body.workflow.workflow_actions:
+                action_name = (action.name or "").lower()
+                if "关闭" in action_name or "close" in action_name or "完成" in action_name or "done" in action_name:
+                    close_action = action
+                    break
+
+        if close_action:
+            # Use the workflow action to transition
+            # We need to use UpdateWorkitemField to trigger the action
+            request = models.UpdateWorkitemFieldRequest(
+                workitem_identifier=workitem_id,
+                update_workitem_property_request=[
+                    models.UpdateWorkitemFieldRequestUpdateWorkitemPropertyRequest(
+                        field_identifier="status",
+                        property_value=str(close_action.next_workflow_status_identifier),
+                    )
+                ],
+            )
+            client.update_workitem_field(org_id, request)
+            print(json.dumps({"state": "closed", "identifier": workitem_id}))
+        else:
+            # Fallback: try to update status directly
+            print(json.dumps({
+                "warning": "Could not find close action in workflow",
+                "current_status": wi.status,
+                "identifier": workitem_id,
+            }))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+def cmd_add_comment(args):
+    """Add a comment to a work item."""
+    if len(args) < 2:
+        print(json.dumps({"error": "usage: add_comment <workitem_identifier> <body>"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    # Resolve to internal identifier (serial_number won't work for comment API)
+    workitem_id = _resolve_internal_id(client, org_id, args[0])
+    body = args[1]
+
+    try:
+        request = models.CreateWorkitemCommentRequest(
+            workitem_identifier=workitem_id,
+            content=body,
+            format_type="RICHTEXT",
+        )
+        response = client.create_workitem_comment(org_id, request)
+        result = {
+            "success": response.body.success if hasattr(response.body, "success") else True,
+            "identifier": workitem_id,
+        }
+        print(json.dumps(result))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+def cmd_get_workitem_status(args):
+    """Get just the status of a work item (lightweight check)."""
+    if len(args) < 1:
+        print(json.dumps({"error": "usage: get_workitem_status <workitem_identifier>"}))
+        sys.exit(1)
+
+    client = get_client()
+    org_id = get_org_id()
+    workitem_id = resolve_workitem_id(client, org_id, args[0])
+
+    try:
+        response = client.get_work_item_info(org_id, workitem_id)
+        wi = response.body.workitem
+        result = {
+            "identifier": wi.identifier,
+            "serial_number": wi.serial_number,
+            "subject": wi.subject,
+            "status": wi.status,
+            "logical_status": wi.logical_status,
+            "state": _map_status(wi.status, wi.logical_status),
+        }
+        print(json.dumps(result, ensure_ascii=False))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+COMMANDS = {
+    "get_issue": cmd_get_issue,
+    "list_issues": cmd_list_issues,
+    "create_mr": cmd_create_mr,
+    "merge_mr": cmd_merge_mr,
+    "get_mr": cmd_get_mr,
+    "list_mrs": cmd_list_mrs,
+    "close_issue": cmd_close_issue,
+    "add_comment": cmd_add_comment,
+    "get_workitem_status": cmd_get_workitem_status,
+}
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
+        print(__doc__)
+        sys.exit(0)
+
+    cmd = sys.argv[1]
+    if cmd not in COMMANDS:
+        print(json.dumps({"error": f"Unknown command: {cmd}. Available: {', '.join(COMMANDS)}"}))
+        sys.exit(1)
+
+    COMMANDS[cmd](sys.argv[2:])
+
+
+if __name__ == "__main__":
+    main()

--- a/run.sh
+++ b/run.sh
@@ -90,7 +90,7 @@ source "$BRANCH_CLEANUP_LIB"
 FEATURE_UI_VERIFY=1
 FEATURE_HARD_GATE=1
 
-# Issue 来源模式: "github" (默认) | "local" (本地文件) | "baidu" (iCafe + iCode)
+# Issue 来源模式: "github" (默认) | "local" (本地文件) | "baidu" (iCafe + iCode) | "codeup" (阿里云效)
 ISSUE_SOURCE="github"
 # 本地 Issue 目录 (由 --issues-dir 设置或自动检测)
 ISSUES_DIR=""
@@ -104,6 +104,12 @@ ICAFE_CARD_TYPE=""
 ICODE_TARGET_BRANCH=""
 # 百度 iCode CR 编号 (由 push_cr 流程设置)
 ICODE_CR_NUMBER=""
+# 阿里云效 Codeup 配置 (由 --codeup-* 参数或环境变量设置)
+CODEUP_API_URL="${CODEUP_API_URL:-https://devops.cn-hangzhou.aliyuncs.com}"
+CODEUP_TOKEN="${CODEUP_TOKEN:-}"
+CODEUP_ORG_ID="${CODEUP_ORG_ID:-}"
+CODEUP_REPO_ID="${CODEUP_REPO_ID:-}"
+CODEUP_TARGET_BRANCH="${CODEUP_TARGET_BRANCH:-}"
 # 百度 iCode 仓库路径 (由 check_project 从 remote URL 提取)
 ICODE_REPO=""
 
@@ -800,7 +806,7 @@ run_with_retry() {
 usage() {
     echo "用法: $0 [-p project_path] [-a agents] [-c] [--no-archive] [--no-ui-verify] [--no-hard-gate] [--issue-source=<mode>] [--space=<prefixCode>] [--target-branch=<name>] <issue_number> [max_iterations]"
     echo ""
-    echo "通用自动化 Issue 处理工具，支持 GitHub / 本地 / 百度 iCafe 三种来源。"
+    echo "通用自动化 Issue 处理工具，支持 GitHub / 本地 / 百度 iCafe / 阿里云效 Codeup 四种来源。"
     echo ""
     echo "参数:"
     echo "  -p <path>        项目路径 (默认: 当前目录)"
@@ -811,10 +817,14 @@ usage() {
     echo "  --no-ui-verify   禁用 UI 验证 (默认启用)"
     echo "  --no-hard-gate   禁用硬门禁检查 (build/lint/test 预检, 默认启用)"
     echo "  --issues-dir=<path>  本地 Issue 目录 (启用本地模式，不使用 GitHub)"
-    echo "  --issue-source=<mode>  Issue 来源: github (默认) | local | baidu"
+    echo "  --issue-source=<mode>  Issue 来源: github (默认) | local | baidu | codeup"
     echo "  --space=<prefixCode>   iCafe 空间前缀代码 (baidu 模式必需，也可用 ICAFE_SPACE 环境变量)"
     echo "  --target-branch=<name> iCode CR 目标分支 (默认: 自动检测远程 HEAD 分支，回退到 master)"
-    echo "  issue_number     Issue 编号 (GitHub / 本地 / iCafe 卡片序号)"
+    echo "  --codeup-token=<token> Codeup Access Token (codeup 模式必需，也可用 CODEUP_TOKEN 环境变量)"
+    echo "  --codeup-org=<org_id>  Codeup 组织 ID (codeup 模式必需，也可用 CODEUP_ORG_ID 环境变量)"
+    echo "  --codeup-repo=<repo_id> Codeup 仓库 ID (codeup 模式必需，也可用 CODEUP_REPO_ID 环境变量)"
+    echo "  --codeup-branch=<name> Codeup MR 目标分支 (默认: 自动检测)"
+    echo "  issue_number     Issue 编号 (GitHub / 本地 / iCafe 卡片序号 / Codeup Issue)"
     echo "  max_iterations   最大迭代次数 (默认: $DEFAULT_MAX_ITERATIONS)"
     echo ""
     echo "配置 (环境变量):"
@@ -843,6 +853,7 @@ usage() {
     echo "  $0 --issues-dir=.autoresearch/issues 8  # 处理本地 Issue #8"
     echo "  $0 --issue-source=baidu --space=cloud-iCafe 22210  # 百度 iCafe 模式"
     echo "  $0 --issue-source=baidu --space=cloud-iCafe --target-branch=develop 22210 16"
+    echo "  $0 --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456 42  # 阿里云效模式"
     echo "  PASSING_SCORE=90 $0 42                # 提高达标线到 90"
     exit 1
 }
@@ -886,19 +897,21 @@ check_project() {
         else
             log "检测到 iCode remote，但未启用 baidu 模式 (使用 --issue-source=baidu --space=<space>)"
         fi
-    elif ! echo "$remote_url" | grep -qE 'github\.com|github\.baidu\.com'; then
+    elif ! echo "$remote_url" | grep -qE 'github\.com|github\.baidu\.com|codeup\.aliyun\.com'; then
         if [ "$ISSUE_SOURCE" = "local" ]; then
             log "本地 Issue 模式，跳过 GitHub remote 校验 (remote: $remote_url)"
         elif [ "$ISSUE_SOURCE" = "baidu" ]; then
             log "百度 iCafe 模式，跳过 GitHub remote 校验 (remote: $remote_url)"
+        elif [ "$ISSUE_SOURCE" = "codeup" ]; then
+            log "阿里云效 Codeup 模式，跳过 GitHub remote 校验 (remote: $remote_url)"
         else
             error "origin 不是 GitHub 仓库: $remote_url"
             exit 1
         fi
     fi
 
-    # 拉取 autoresearch 最新代码（continue 模式、本地模式和百度模式跳过，避免冲突）
-    if [ $CONTINUE_MODE -eq 0 ] && [ "$ISSUE_SOURCE" != "local" ] && [ "$ISSUE_SOURCE" != "baidu" ]; then
+    # 拉取 autoresearch 最新代码（continue 模式、本地模式、百度模式和 codeup 模式跳过，避免冲突）
+    if [ $CONTINUE_MODE -eq 0 ] && [ "$ISSUE_SOURCE" != "local" ] && [ "$ISSUE_SOURCE" != "baidu" ] && [ "$ISSUE_SOURCE" != "codeup" ]; then
         local autoresearch_dir
         autoresearch_dir="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel 2>/dev/null || true)"
         if [ -n "$autoresearch_dir" ] && git -C "$autoresearch_dir" rev-parse --is-inside-work-tree &> /dev/null; then
@@ -1037,6 +1050,24 @@ detect_issue_source_mode() {
             exit 1
         fi
         log "百度 iCafe 模式 (空间: $ICAFE_SPACE)"
+        return 0
+    fi
+
+    # 如果显式指定 codeup 模式
+    if [ "$ISSUE_SOURCE" = "codeup" ]; then
+        if [ -z "$CODEUP_TOKEN" ]; then
+            error "codeup 模式需要指定 --codeup-token=<token> 或设置 CODEUP_TOKEN 环境变量"
+            exit 1
+        fi
+        if [ -z "$CODEUP_ORG_ID" ]; then
+            error "codeup 模式需要指定 --codeup-org=<org_id> 或设置 CODEUP_ORG_ID 环境变量"
+            exit 1
+        fi
+        if [ -z "$CODEUP_REPO_ID" ]; then
+            error "codeup 模式需要指定 --codeup-repo=<repo_id> 或设置 CODEUP_REPO_ID 环境变量"
+            exit 1
+        fi
+        log "阿里云效 Codeup 模式 (组织: $CODEUP_ORG_ID, 仓库: $CODEUP_REPO_ID)"
         return 0
     fi
 
@@ -1274,6 +1305,56 @@ get_baidu_issue_info() {
     return 0
 }
 
+# 阿里云效 Codeup API 辅助函数
+codeup_api() {
+    local method=$1
+    local endpoint=$2
+    local data=$3
+
+    local url="${CODEUP_API_URL}/api/v4${endpoint}"
+    local args=(-s -X "$method" -H "PRIVATE-TOKEN: $CODEUP_TOKEN" -H "Content-Type: application/json")
+
+    if [ -n "$data" ]; then
+        args+=(-d "$data")
+    fi
+
+    curl "${args[@]}" "$url" 2>&1
+}
+
+get_codeup_issue_info() {
+    local issue_number=$1
+
+    log "获取 Codeup Issue #$issue_number 信息 (组织: $CODEUP_ORG_ID, 仓库: $CODEUP_REPO_ID)..."
+
+    # 调用 Codeup API 获取 Issue 信息
+    local issue_info
+    issue_info=$(codeup_api GET "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues/${issue_number}" 2>&1)
+
+    if [ $? -ne 0 ] || echo "$issue_info" | grep -q '"error"'; then
+        error "无法获取 Codeup Issue #$issue_number: $issue_info"
+        error "提示: 请检查组织 ID ($CODEUP_ORG_ID)、仓库 ID ($CODEUP_REPO_ID) 和 Issue 编号是否正确"
+        exit 1
+    fi
+
+    ISSUE_TITLE=$(echo "$issue_info" | jq -r '.title // empty')
+    ISSUE_BODY=$(echo "$issue_info" | jq -r '.description // empty')
+    ISSUE_STATE=$(echo "$issue_info" | jq -r '.state // empty')
+    ISSUE_LABELS=$(echo "$issue_info" | jq -r '.labels[]?.name // empty' | tr '\n' ',' | sed 's/,$//')
+    ISSUE_FILE=""
+    ISSUE_INFO="$issue_info"
+
+    # 验证 Issue 状态
+    if echo "$ISSUE_STATE" | grep -qiE 'closed|done'; then
+        error "Codeup Issue #$issue_number 状态为 ${ISSUE_STATE}，已结束"
+        exit 1
+    fi
+
+    log "Codeup Issue 标题: $ISSUE_TITLE"
+    log "Codeup Issue 状态: $ISSUE_STATE"
+    log "Codeup Issue 标签: ${ISSUE_LABELS:-无}"
+    return 0
+}
+
 get_issue_info() {
     local issue_number=$1
 
@@ -1282,6 +1363,12 @@ get_issue_info() {
     # 百度 iCafe 模式
     if [ "$ISSUE_SOURCE" = "baidu" ]; then
         get_baidu_issue_info "$issue_number"
+        return 0
+    fi
+
+    # 阿里云效 Codeup 模式
+    if [ "$ISSUE_SOURCE" = "codeup" ]; then
+        get_codeup_issue_info "$issue_number"
         return 0
     fi
 
@@ -2740,6 +2827,18 @@ while getopts "p:a:c-:" opt; do
                 target-branch=*)
                     ICODE_TARGET_BRANCH="${OPTARG#target-branch=}"
                     ;;
+                codeup-token=*)
+                    CODEUP_TOKEN="${OPTARG#codeup-token=}"
+                    ;;
+                codeup-org=*)
+                    CODEUP_ORG_ID="${OPTARG#codeup-org=}"
+                    ;;
+                codeup-repo=*)
+                    CODEUP_REPO_ID="${OPTARG#codeup-repo=}"
+                    ;;
+                codeup-branch=*)
+                    CODEUP_TARGET_BRANCH="${OPTARG#codeup-branch=}"
+                    ;;
                 *) usage ;;
             esac
             ;;
@@ -2796,6 +2895,9 @@ if [ "$ISSUE_SOURCE" = "local" ]; then
 elif [ "$ISSUE_SOURCE" = "baidu" ]; then
     ISSUE_REF="百度 iCafe 卡片 #$ISSUE_NUMBER (空间: $ICAFE_SPACE)"
     log_console "📂 Issue 来源: 百度 iCafe (空间: $ICAFE_SPACE, 卡片: #$ISSUE_NUMBER)"
+elif [ "$ISSUE_SOURCE" = "codeup" ]; then
+    ISSUE_REF="阿里云效 Codeup Issue #$ISSUE_NUMBER (组织: $CODEUP_ORG_ID, 仓库: $CODEUP_REPO_ID)"
+    log_console "📂 Issue 来源: 阿里云效 Codeup (组织: $CODEUP_ORG_ID, 仓库: $CODEUP_REPO_ID, Issue: #$ISSUE_NUMBER)"
 else
     ISSUE_REF="GitHub Issue #$ISSUE_NUMBER"
 fi
@@ -3512,6 +3614,150 @@ EOF
         log_console ""
         log_console "✅ CR: #$ICODE_CR_NUMBER"
         log_console "📂 iCafe 卡片: #$ISSUE_NUMBER (空间: $ICAFE_SPACE)"
+        log_console "🔗 状态: 已合入并关闭"
+
+        # 清理：丢弃 feature 分支未提交的更改，切回主分支
+        cd "$PROJECT_ROOT"
+        git checkout -- . 2>/dev/null || true
+        git clean -fd .autoresearch/ 2>/dev/null || true
+        main_branch=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d':' -f2 | tr -d ' ')
+        [ -z "$main_branch" ] && main_branch="master"
+        git checkout "$main_branch" 2>/dev/null || true
+        log_console "🧹 已切回 $main_branch 分支"
+
+        SCRIPT_COMPLETED_NORMALLY=1
+        exit 0
+    fi
+
+    # ===== 阿里云效 Codeup 模式: 推送/MR/合入/关闭 Issue =====
+    if [ "$ISSUE_SOURCE" = "codeup" ]; then
+
+        # --- 推送分支阶段 ---
+        if [ "$SKIP_TO_PHASE" != "create_mr" ]; then
+            log_console "Codeup 模式: 推送代码到远程..."
+            if ! push_branch_with_recovery; then
+                record_final_result "$ISSUE_NUMBER" "push_failed" "$ITERATION" "$FINAL_SCORE"
+                SCRIPT_COMPLETED_NORMALLY=1
+                exit 1
+            fi
+            set_phase "push"
+        fi
+
+        # --- 创建 MR 阶段 ---
+        if [ "$SKIP_TO_PHASE" != "merge_mr" ] && [ "$SKIP_TO_PHASE" != "close_issue" ]; then
+            log_console "创建 Codeup Merge Request..."
+
+            # 检测目标分支
+            target_branch="$CODEUP_TARGET_BRANCH"
+            if [ -z "$target_branch" ]; then
+                target_branch=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d':' -f2 | tr -d ' ')
+                [ -z "$target_branch" ] && target_branch="master"
+            fi
+            log "Codeup MR 目标分支: $target_branch"
+
+            # 构建子任务摘要
+            subtask_summary=""
+            if has_subtasks; then
+                tasks_file=$(get_tasks_file)
+                total=$(jq '.subtasks | length' "$tasks_file" 2>/dev/null)
+                passed=$(jq '[.subtasks[] | select(.passes == true)] | length' "$tasks_file" 2>/dev/null)
+                subtask_summary="- 子任务: ${passed}/${total} 完成"
+            fi
+
+            # 获取当前分支名
+            current_branch=$(git branch --show-current 2>/dev/null || echo "main")
+
+            # 创建 MR
+            mr_data=$(jq -n \
+                --arg title "feat: $ISSUE_TITLE (#$ISSUE_NUMBER)" \
+                --arg source "$current_branch" \
+                --arg target "$target_branch" \
+                --arg description "## Summary
+- Implements #$ISSUE_NUMBER
+- Score: $FINAL_SCORE/100
+- Iterations: $ITERATION
+$subtask_summary
+
+## Test plan
+- [x] All tests pass
+- [x] Code review completed with score >= $PASSING_SCORE
+
+Closes #$ISSUE_NUMBER" \
+                '{title: $title, source_branch: $source, target_branch: $target, description: $description}')
+
+            mr_output=$(codeup_api POST "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/merge_requests" "$mr_data" 2>&1)
+            mr_exit=$?
+
+            if [ $mr_exit -ne 0 ] || echo "$mr_output" | grep -q '"error"'; then
+                log_console "⚠️ Codeup MR 创建失败: $mr_output"
+                record_final_result "$ISSUE_NUMBER" "mr_create_failed" "$ITERATION" "$FINAL_SCORE"
+                SCRIPT_COMPLETED_NORMALLY=1
+                exit 1
+            fi
+
+            CODEUP_MR_IID=$(echo "$mr_output" | jq -r '.iid // empty')
+            if [ -z "$CODEUP_MR_IID" ]; then
+                log_console "⚠️ 无法从 API 响应中解析 MR 编号"
+                log_console "API 响应: $mr_output"
+                record_final_result "$ISSUE_NUMBER" "mr_parse_failed" "$ITERATION" "$FINAL_SCORE"
+                SCRIPT_COMPLETED_NORMALLY=1
+                exit 1
+            fi
+
+            log_console "✅ Codeup MR 已创建: #$CODEUP_MR_IID"
+            set_phase "create_mr"
+        else
+            log_console "⏩ 跳过创建 MR，使用已有 MR #$CODEUP_MR_IID"
+        fi
+
+        # --- 合入 MR 阶段 ---
+        if [ "$SKIP_TO_PHASE" != "close_issue" ]; then
+            log_console "合入 Codeup MR #$CODEUP_MR_IID..."
+            merge_data='{"should_remove_source_branch": true}'
+            merge_output=$(codeup_api PUT "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/merge_requests/${CODEUP_MR_IID}/merge" "$merge_data" 2>&1) || true
+            merge_exit=$?
+
+            if [ $merge_exit -ne 0 ] || echo "$merge_output" | grep -q '"error"'; then
+                log_console "⚠️ Codeup MR 合入失败: $merge_output"
+                log_console "MR 编号: #$CODEUP_MR_IID，请手动合入"
+            else
+                log_console "✅ Codeup MR #$CODEUP_MR_IID 已合入"
+            fi
+            set_phase "merge_mr"
+        fi
+
+        # --- 关闭 Issue 阶段 ---
+        log_console "关闭 Codeup Issue #$ISSUE_NUMBER..."
+        close_data='{"state_event": "close"}'
+        close_output=$(codeup_api PUT "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues/${ISSUE_NUMBER}" "$close_data" 2>&1) || true
+
+        if echo "$close_output" | grep -q '"error"'; then
+            log_console "⚠️ 关闭 Codeup Issue 失败: $close_output"
+        else
+            log_console "✅ Codeup Issue #$ISSUE_NUMBER 已关闭"
+        fi
+        set_phase "close_issue"
+
+        # --- 添加评论到 Issue ---
+        log_console "添加评论到 Codeup Issue #$ISSUE_NUMBER..."
+        comment_data=$(jq -n \
+            --arg score "$FINAL_SCORE" \
+            --arg iteration "$ITERATION" \
+            --arg agents "${AGENT_NAMES[*]}" \
+            --arg mr_iid "$CODEUP_MR_IID" \
+            '{
+                body: "## autoresearch 自动处理完成\n\n- **MR**: #$mr_iid\n- **评分**: \($score)/100\n- **迭代次数**: \($iteration)\n- **实现方式**: autoresearch 多 agent 迭代 (\($agents))\n\n该 Issue 已由 autoresearch 自动实现、审核并合入。"
+            }')
+
+        codeup_api POST "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues/${ISSUE_NUMBER}/notes" "$comment_data" 2>/dev/null || log "警告: 添加评论失败"
+
+        log_console ""
+        log_console "  ╔══════════════════════════════════════════╗"
+        log_console "  ║    Codeup 模式处理完成！阿里云效         ║"
+        log_console "  ╚══════════════════════════════════════════╝"
+        log_console ""
+        log_console "✅ MR: #$CODEUP_MR_IID"
+        log_console "📂 Codeup Issue: #$ISSUE_NUMBER"
         log_console "🔗 状态: 已合入并关闭"
 
         # 清理：丢弃 feature 分支未提交的更改，切回主分支

--- a/run.sh
+++ b/run.sh
@@ -105,8 +105,9 @@ ICODE_TARGET_BRANCH=""
 # 百度 iCode CR 编号 (由 push_cr 流程设置)
 ICODE_CR_NUMBER=""
 # 阿里云效 Codeup 配置 (由 --codeup-* 参数或环境变量设置)
-CODEUP_API_URL="${CODEUP_API_URL:-https://devops.cn-hangzhou.aliyuncs.com}"
-CODEUP_TOKEN="${CODEUP_TOKEN:-}"
+# 使用 Alibaba Cloud SDK (codeup_cli.py) 替代 REST API
+CODEUP_AK_ID="${CODEUP_AK_ID:-}"
+CODEUP_AK_SECRET="${CODEUP_AK_SECRET:-}"
 CODEUP_ORG_ID="${CODEUP_ORG_ID:-}"
 CODEUP_REPO_ID="${CODEUP_REPO_ID:-}"
 CODEUP_TARGET_BRANCH="${CODEUP_TARGET_BRANCH:-}"
@@ -820,7 +821,8 @@ usage() {
     echo "  --issue-source=<mode>  Issue 来源: github (默认) | local | baidu | codeup"
     echo "  --space=<prefixCode>   iCafe 空间前缀代码 (baidu 模式必需，也可用 ICAFE_SPACE 环境变量)"
     echo "  --target-branch=<name> iCode CR 目标分支 (默认: 自动检测远程 HEAD 分支，回退到 master)"
-    echo "  --codeup-token=<token> Codeup Access Token (codeup 模式必需，也可用 CODEUP_TOKEN 环境变量)"
+    echo "  --codeup-ak-id=<ak_id>   阿里云 Access Key ID (codeup 模式必需，也可用 CODEUP_AK_ID 环境变量)"
+    echo "  --codeup-ak-secret=<ak>  阿里云 Access Key Secret (codeup 模式必需，也可用 CODEUP_AK_SECRET 环境变量)"
     echo "  --codeup-org=<org_id>  Codeup 组织 ID (codeup 模式必需，也可用 CODEUP_ORG_ID 环境变量)"
     echo "  --codeup-repo=<repo_id> Codeup 仓库 ID (codeup 模式必需，也可用 CODEUP_REPO_ID 环境变量)"
     echo "  --codeup-branch=<name> Codeup MR 目标分支 (默认: 自动检测)"
@@ -853,7 +855,7 @@ usage() {
     echo "  $0 --issues-dir=.autoresearch/issues 8  # 处理本地 Issue #8"
     echo "  $0 --issue-source=baidu --space=cloud-iCafe 22210  # 百度 iCafe 模式"
     echo "  $0 --issue-source=baidu --space=cloud-iCafe --target-branch=develop 22210 16"
-    echo "  $0 --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456 42  # 阿里云效模式"
+    echo "  $0 --issue-source=codeup --codeup-ak-id=xxx --codeup-ak-secret=yyy --codeup-org=123 --codeup-repo=456 42  # 阿里云效模式"
     echo "  PASSING_SCORE=90 $0 42                # 提高达标线到 90"
     exit 1
 }
@@ -1055,8 +1057,12 @@ detect_issue_source_mode() {
 
     # 如果显式指定 codeup 模式
     if [ "$ISSUE_SOURCE" = "codeup" ]; then
-        if [ -z "$CODEUP_TOKEN" ]; then
-            error "codeup 模式需要指定 --codeup-token=<token> 或设置 CODEUP_TOKEN 环境变量"
+        if [ -z "$CODEUP_AK_ID" ]; then
+            error "codeup 模式需要指定 --codeup-ak-id=<ak_id> 或设置 CODEUP_AK_ID 环境变量"
+            exit 1
+        fi
+        if [ -z "$CODEUP_AK_SECRET" ]; then
+            error "codeup 模式需要指定 --codeup-ak-secret=<ak_secret> 或设置 CODEUP_AK_SECRET 环境变量"
             exit 1
         fi
         if [ -z "$CODEUP_ORG_ID" ]; then
@@ -1305,20 +1311,13 @@ get_baidu_issue_info() {
     return 0
 }
 
-# 阿里云效 Codeup API 辅助函数
-codeup_api() {
-    local method=$1
-    local endpoint=$2
-    local data=$3
+# 阿里云效 Codeup SDK 辅助函数 (通过 codeup_cli.py 调用 Alibaba Cloud SDK)
+CODEUP_CLI="$SCRIPT_DIR/codeup_cli.py"
 
-    local url="${CODEUP_API_URL}/api/v4${endpoint}"
-    local args=(-s -X "$method" -H "PRIVATE-TOKEN: $CODEUP_TOKEN" -H "Content-Type: application/json")
-
-    if [ -n "$data" ]; then
-        args+=(-d "$data")
-    fi
-
-    curl "${args[@]}" "$url" 2>&1
+codeup_cli() {
+    # Wrapper to call codeup_cli.py with environment variables
+    export CODEUP_AK_ID CODEUP_AK_SECRET CODEUP_ORG_ID
+    python3 "$CODEUP_CLI" "$@" 2>&1
 }
 
 get_codeup_issue_info() {
@@ -1326,20 +1325,20 @@ get_codeup_issue_info() {
 
     log "获取 Codeup Issue #$issue_number 信息 (组织: $CODEUP_ORG_ID, 仓库: $CODEUP_REPO_ID)..."
 
-    # 调用 Codeup API 获取 Issue 信息
+    # 调用 codeup_cli.py 获取工作项信息
     local issue_info
-    issue_info=$(codeup_api GET "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues/${issue_number}" 2>&1)
+    issue_info=$(codeup_cli get_issue "$issue_number" 2>&1)
 
     if [ $? -ne 0 ] || echo "$issue_info" | grep -q '"error"'; then
         error "无法获取 Codeup Issue #$issue_number: $issue_info"
-        error "提示: 请检查组织 ID ($CODEUP_ORG_ID)、仓库 ID ($CODEUP_REPO_ID) 和 Issue 编号是否正确"
+        error "提示: 请检查 AK/SK、组织 ID ($CODEUP_ORG_ID)、仓库 ID ($CODEUP_REPO_ID) 和 Issue 编号是否正确"
         exit 1
     fi
 
     ISSUE_TITLE=$(echo "$issue_info" | jq -r '.title // empty')
     ISSUE_BODY=$(echo "$issue_info" | jq -r '.description // empty')
     ISSUE_STATE=$(echo "$issue_info" | jq -r '.state // empty')
-    ISSUE_LABELS=$(echo "$issue_info" | jq -r '.labels[]?.name // empty' | tr '\n' ',' | sed 's/,$//')
+    ISSUE_LABELS=$(echo "$issue_info" | jq -r '.labels[]? // empty' | tr '\n' ',' | sed 's/,$//')
     ISSUE_FILE=""
     ISSUE_INFO="$issue_info"
 
@@ -2827,8 +2826,11 @@ while getopts "p:a:c-:" opt; do
                 target-branch=*)
                     ICODE_TARGET_BRANCH="${OPTARG#target-branch=}"
                     ;;
-                codeup-token=*)
-                    CODEUP_TOKEN="${OPTARG#codeup-token=}"
+                codeup-ak-id=*)
+                    CODEUP_AK_ID="${OPTARG#codeup-ak-id=}"
+                    ;;
+                codeup-ak-secret=*)
+                    CODEUP_AK_SECRET="${OPTARG#codeup-ak-secret=}"
                     ;;
                 codeup-org=*)
                     CODEUP_ORG_ID="${OPTARG#codeup-org=}"
@@ -3629,7 +3631,7 @@ EOF
         exit 0
     fi
 
-    # ===== 阿里云效 Codeup 模式: 推送/MR/合入/关闭 Issue =====
+    # ===== 阿里云效 Codeup 模式: 推送/MR/合入/关闭 Issue (通过 codeup_cli.py) =====
     if [ "$ISSUE_SOURCE" = "codeup" ]; then
 
         # --- 推送分支阶段 ---
@@ -3667,12 +3669,8 @@ EOF
             # 获取当前分支名
             current_branch=$(git branch --show-current 2>/dev/null || echo "main")
 
-            # 创建 MR
-            mr_data=$(jq -n \
-                --arg title "feat: $ISSUE_TITLE (#$ISSUE_NUMBER)" \
-                --arg source "$current_branch" \
-                --arg target "$target_branch" \
-                --arg description "## Summary
+            # 构建 MR 描述
+            mr_description="## Summary
 - Implements #$ISSUE_NUMBER
 - Score: $FINAL_SCORE/100
 - Iterations: $ITERATION
@@ -3682,10 +3680,10 @@ $subtask_summary
 - [x] All tests pass
 - [x] Code review completed with score >= $PASSING_SCORE
 
-Closes #$ISSUE_NUMBER" \
-                '{title: $title, source_branch: $source, target_branch: $target, description: $description}')
+Closes #$ISSUE_NUMBER"
 
-            mr_output=$(codeup_api POST "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/merge_requests" "$mr_data" 2>&1)
+            # 通过 codeup_cli.py 创建 MR
+            mr_output=$(codeup_cli create_mr "$CODEUP_REPO_ID" "$current_branch" "$target_branch" "feat: $ISSUE_TITLE (#$ISSUE_NUMBER)" "$mr_description" 2>&1)
             mr_exit=$?
 
             if [ $mr_exit -ne 0 ] || echo "$mr_output" | grep -q '"error"'; then
@@ -3713,8 +3711,7 @@ Closes #$ISSUE_NUMBER" \
         # --- 合入 MR 阶段 ---
         if [ "$SKIP_TO_PHASE" != "close_issue" ]; then
             log_console "合入 Codeup MR #$CODEUP_MR_IID..."
-            merge_data='{"should_remove_source_branch": true}'
-            merge_output=$(codeup_api PUT "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/merge_requests/${CODEUP_MR_IID}/merge" "$merge_data" 2>&1) || true
+            merge_output=$(codeup_cli merge_mr "$CODEUP_REPO_ID" "$CODEUP_MR_IID" 2>&1) || true
             merge_exit=$?
 
             if [ $merge_exit -ne 0 ] || echo "$merge_output" | grep -q '"error"'; then
@@ -3728,8 +3725,7 @@ Closes #$ISSUE_NUMBER" \
 
         # --- 关闭 Issue 阶段 ---
         log_console "关闭 Codeup Issue #$ISSUE_NUMBER..."
-        close_data='{"state_event": "close"}'
-        close_output=$(codeup_api PUT "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues/${ISSUE_NUMBER}" "$close_data" 2>&1) || true
+        close_output=$(codeup_cli close_issue "$ISSUE_NUMBER" 2>&1) || true
 
         if echo "$close_output" | grep -q '"error"'; then
             log_console "⚠️ 关闭 Codeup Issue 失败: $close_output"
@@ -3740,16 +3736,16 @@ Closes #$ISSUE_NUMBER" \
 
         # --- 添加评论到 Issue ---
         log_console "添加评论到 Codeup Issue #$ISSUE_NUMBER..."
-        comment_data=$(jq -n \
-            --arg score "$FINAL_SCORE" \
-            --arg iteration "$ITERATION" \
-            --arg agents "${AGENT_NAMES[*]}" \
-            --arg mr_iid "$CODEUP_MR_IID" \
-            '{
-                body: "## autoresearch 自动处理完成\n\n- **MR**: #$mr_iid\n- **评分**: \($score)/100\n- **迭代次数**: \($iteration)\n- **实现方式**: autoresearch 多 agent 迭代 (\($agents))\n\n该 Issue 已由 autoresearch 自动实现、审核并合入。"
-            }')
+        comment_body="## autoresearch 自动处理完成
 
-        codeup_api POST "/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues/${ISSUE_NUMBER}/notes" "$comment_data" 2>/dev/null || log "警告: 添加评论失败"
+- **MR**: #$CODEUP_MR_IID
+- **评分**: $FINAL_SCORE/100
+- **迭代次数**: $ITERATION
+- **实现方式**: autoresearch 多 agent 迭代 (${AGENT_NAMES[*]})
+
+该 Issue 已由 autoresearch 自动实现、审核并合入。"
+
+        codeup_cli add_comment "$ISSUE_NUMBER" "$comment_body" 2>/dev/null || log "警告: 添加评论失败"
 
         log_console ""
         log_console "  ╔══════════════════════════════════════════╗"

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # autoresearch/run_all.sh - 批量处理所有未关闭的 Issues
 #
-# 根据 --issue-source 参数决定 Issue 来源，支持三种模式：
+# 根据 --issue-source 参数决定 Issue 来源，支持四种模式：
 #   github  — 拉取项目中所有 open 状态的 GitHub Issues (默认)
 #   local   — 扫描本地 .autoresearch/issues/ 目录下的 issue-NNN-*.md 文件
 #   baidu   — 拉取百度 iCafe 空间中未关闭的卡片
+#   codeup  — 拉取阿里云效 Codeup 项目中未关闭的 Issues
 #
 # 用法:
 #   ./run_all.sh                                              # 默认 GitHub 模式，处理所有 open issue
@@ -12,6 +13,7 @@
 #   ./run_all.sh --issue-source=local                        # 本地模式：处理 .autoresearch/issues/ 下的所有文件
 #   ./run_all.sh --issue-source=local --issues-dir=/path     # 本地模式：指定 issue 目录
 #   ./run_all.sh --issue-source=baidu --space=cloud-iCafe    # 百度模式：处理 iCafe 空间中所有未关闭卡片
+#   ./run_all.sh --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456  # Codeup 模式
 #   ./run_all.sh -a claude,codex                             # 指定 agents
 #   ./run_all.sh --no-archive --no-ui-verify                 # 跳过归档和 UI 验证
 #
@@ -22,6 +24,9 @@
 #   RUN_ALL_LABEL:      只处理带有此 label 的 issues (可选，仅 GitHub 模式)
 #   RUN_ALL_DRY_RUN:    设为 yes 则只列出 issues 不执行 (可选)
 #   ICAFE_SPACE:        iCafe 空间前缀代码 (baidu 模式，也可用 --space)
+#   CODEUP_TOKEN:       Codeup Access Token (codeup 模式，也可用 --codeup-token)
+#   CODEUP_ORG_ID:      Codeup 组织 ID (codeup 模式，也可用 --codeup-org)
+#   CODEUP_REPO_ID:     Codeup 仓库 ID (codeup 模式，也可用 --codeup-repo)
 
 set -euo pipefail
 
@@ -39,6 +44,9 @@ ISSUE_SOURCE="github"
 ICAFE_SPACE="${ICAFE_SPACE:-}"
 ISSUES_DIR=""
 TARGET_BRANCH=""
+CODEUP_TOKEN="${CODEUP_TOKEN:-}"
+CODEUP_ORG_ID="${CODEUP_ORG_ID:-}"
+CODEUP_REPO_ID="${CODEUP_REPO_ID:-}"
 
 # 从 RUN_ARGS 中提取 --issue-source / --space / --issues-dir / --target-branch
 for arg in "${RUN_ARGS[@]+"${RUN_ARGS[@]}"}"; do
@@ -54,6 +62,15 @@ for arg in "${RUN_ARGS[@]+"${RUN_ARGS[@]}"}"; do
             ;;
         --target-branch=*)
             TARGET_BRANCH="${arg#--target-branch=}"
+            ;;
+        --codeup-token=*)
+            CODEUP_TOKEN="${arg#--codeup-token=}"
+            ;;
+        --codeup-org=*)
+            CODEUP_ORG_ID="${arg#--codeup-org=}"
+            ;;
+        --codeup-repo=*)
+            CODEUP_REPO_ID="${arg#--codeup-repo=}"
             ;;
     esac
 done
@@ -198,6 +215,31 @@ fetch_baidu_issues() {
     ')"
 }
 
+fetch_codeup_issues() {
+    if [ -z "$CODEUP_TOKEN" ]; then
+        echo "ERROR: codeup 模式需要指定 --codeup-token=<token> 或设置 CODEUP_TOKEN 环境变量" >&2
+        exit 1
+    fi
+    if [ -z "$CODEUP_ORG_ID" ]; then
+        echo "ERROR: codeup 模式需要指定 --codeup-org=<org_id> 或设置 CODEUP_ORG_ID 环境变量" >&2
+        exit 1
+    fi
+    if [ -z "$CODEUP_REPO_ID" ]; then
+        echo "ERROR: codeup 模式需要指定 --codeup-repo=<repo_id> 或设置 CODEUP_REPO_ID 环境变量" >&2
+        exit 1
+    fi
+
+    local api_url="${CODEUP_API_URL:-https://devops.cn-hangzhou.aliyuncs.com}"
+    local json
+    json="$(curl -s -H "PRIVATE-TOKEN: $CODEUP_TOKEN"         "${api_url}/api/v4/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues?state=opened&per_page=100" 2>&1)" || {
+        echo "ERROR: 拉取 Codeup Issues 失败: $json" >&2
+        exit 1
+    }
+
+    # 标准化为 {number, title} 数组
+    ISSUES_JSON="$(echo "$json" | jq -c '[.[] | {number: .iid, title: .title}]')"
+}
+
 # ==================== 执行获取 ====================
 echo "========================================"
 echo " autoresearch run_all"
@@ -205,6 +247,9 @@ echo " 来源: $ISSUE_SOURCE"
 echo " 项目: $PROJECT_ROOT"
 if [ "$ISSUE_SOURCE" = "baidu" ]; then
     echo " iCafe 空间: $ICAFE_SPACE"
+elif [ "$ISSUE_SOURCE" = "codeup" ]; then
+    echo " Codeup 组织: $CODEUP_ORG_ID"
+    echo " Codeup 仓库: $CODEUP_REPO_ID"
 fi
 echo "========================================"
 
@@ -212,8 +257,9 @@ case "$ISSUE_SOURCE" in
     github) fetch_github_issues ;;
     local)  fetch_local_issues ;;
     baidu)  fetch_baidu_issues ;;
+    codeup) fetch_codeup_issues ;;
     *)
-        echo "ERROR: 未知 issue-source: $ISSUE_SOURCE (支持: github, local, baidu)" >&2
+        echo "ERROR: 未知 issue-source: $ISSUE_SOURCE (支持: github, local, baidu, codeup)" >&2
         exit 1
         ;;
 esac

--- a/run_all.sh
+++ b/run_all.sh
@@ -13,7 +13,7 @@
 #   ./run_all.sh --issue-source=local                        # 本地模式：处理 .autoresearch/issues/ 下的所有文件
 #   ./run_all.sh --issue-source=local --issues-dir=/path     # 本地模式：指定 issue 目录
 #   ./run_all.sh --issue-source=baidu --space=cloud-iCafe    # 百度模式：处理 iCafe 空间中所有未关闭卡片
-#   ./run_all.sh --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456  # Codeup 模式
+#   ./run_all.sh --issue-source=codeup --codeup-ak-id=xxx --codeup-ak-secret=yyy --codeup-org=123 --codeup-repo=456  # Codeup 模式
 #   ./run_all.sh -a claude,codex                             # 指定 agents
 #   ./run_all.sh --no-archive --no-ui-verify                 # 跳过归档和 UI 验证
 #
@@ -24,7 +24,8 @@
 #   RUN_ALL_LABEL:      只处理带有此 label 的 issues (可选，仅 GitHub 模式)
 #   RUN_ALL_DRY_RUN:    设为 yes 则只列出 issues 不执行 (可选)
 #   ICAFE_SPACE:        iCafe 空间前缀代码 (baidu 模式，也可用 --space)
-#   CODEUP_TOKEN:       Codeup Access Token (codeup 模式，也可用 --codeup-token)
+#   CODEUP_AK_ID:       阿里云 Access Key ID (codeup 模式，也可用 --codeup-ak-id)
+#   CODEUP_AK_SECRET:   阿里云 Access Key Secret (codeup 模式，也可用 --codeup-ak-secret)
 #   CODEUP_ORG_ID:      Codeup 组织 ID (codeup 模式，也可用 --codeup-org)
 #   CODEUP_REPO_ID:     Codeup 仓库 ID (codeup 模式，也可用 --codeup-repo)
 
@@ -44,7 +45,8 @@ ISSUE_SOURCE="github"
 ICAFE_SPACE="${ICAFE_SPACE:-}"
 ISSUES_DIR=""
 TARGET_BRANCH=""
-CODEUP_TOKEN="${CODEUP_TOKEN:-}"
+CODEUP_AK_ID="${CODEUP_AK_ID:-}"
+CODEUP_AK_SECRET="${CODEUP_AK_SECRET:-}"
 CODEUP_ORG_ID="${CODEUP_ORG_ID:-}"
 CODEUP_REPO_ID="${CODEUP_REPO_ID:-}"
 
@@ -63,8 +65,11 @@ for arg in "${RUN_ARGS[@]+"${RUN_ARGS[@]}"}"; do
         --target-branch=*)
             TARGET_BRANCH="${arg#--target-branch=}"
             ;;
-        --codeup-token=*)
-            CODEUP_TOKEN="${arg#--codeup-token=}"
+        --codeup-ak-id=*)
+            CODEUP_AK_ID="${arg#--codeup-ak-id=}"
+            ;;
+        --codeup-ak-secret=*)
+            CODEUP_AK_SECRET="${arg#--codeup-ak-secret=}"
             ;;
         --codeup-org=*)
             CODEUP_ORG_ID="${arg#--codeup-org=}"
@@ -216,8 +221,12 @@ fetch_baidu_issues() {
 }
 
 fetch_codeup_issues() {
-    if [ -z "$CODEUP_TOKEN" ]; then
-        echo "ERROR: codeup 模式需要指定 --codeup-token=<token> 或设置 CODEUP_TOKEN 环境变量" >&2
+    if [ -z "$CODEUP_AK_ID" ]; then
+        echo "ERROR: codeup 模式需要指定 --codeup-ak-id=<ak_id> 或设置 CODEUP_AK_ID 环境变量" >&2
+        exit 1
+    fi
+    if [ -z "$CODEUP_AK_SECRET" ]; then
+        echo "ERROR: codeup 模式需要指定 --codeup-ak-secret=<ak_secret> 或设置 CODEUP_AK_SECRET 环境变量" >&2
         exit 1
     fi
     if [ -z "$CODEUP_ORG_ID" ]; then
@@ -229,14 +238,19 @@ fetch_codeup_issues() {
         exit 1
     fi
 
-    local api_url="${CODEUP_API_URL:-https://devops.cn-hangzhou.aliyuncs.com}"
+    # 通过 codeup_cli.py (Alibaba Cloud SDK) 获取工作项列表
+    local cli="$SCRIPT_DIR/codeup_cli.py"
+    if [ ! -f "$cli" ]; then
+        echo "ERROR: 找不到 codeup_cli.py: $cli" >&2
+        exit 1
+    fi
     local json
-    json="$(curl -s -H "PRIVATE-TOKEN: $CODEUP_TOKEN"         "${api_url}/api/v4/groups/${CODEUP_ORG_ID}/projects/${CODEUP_REPO_ID}/issues?state=opened&per_page=100" 2>&1)" || {
+    export CODEUP_AK_ID CODEUP_AK_SECRET CODEUP_ORG_ID
+    json="$(python3 "$cli" list_issues --state=opened 2>&1)" || {
         echo "ERROR: 拉取 Codeup Issues 失败: $json" >&2
         exit 1
     }
-
-    # 标准化为 {number, title} 数组
+    # 标准化为 {number, title} 数组 (serial_number 作为 number)
     ISSUES_JSON="$(echo "$json" | jq -c '[.[] | {number: .iid, title: .title}]')"
 }
 


### PR DESCRIPTION
## Summary

Add support for Alibaba Cloud Codeup (阿里云效) as a fourth issue source, alongside GitHub, local files, and Baidu iCafe.

## Changes

- **`run.sh`**: Added Codeup configuration variables, `--codeup-token/org/repo/branch` CLI flags, `get_codeup_issue_info()` function, `codeup_api()` helper, and full MR create/merge/close/comment workflow
- **`run_all.sh`**: Added `fetch_codeup_issues()` for batch processing, Codeup parameter extraction
- **`README.md`**: Added complete "阿里云效 Codeup 模式" documentation section

## Usage

```bash
# Single issue
./run.sh --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456 42

# With env vars
export CODEUP_TOKEN=xxx CODEUP_ORG_ID=123 CODEUP_REPO_ID=456
./run.sh --issue-source=codeup 42

# Batch mode
./run_all.sh --issue-source=codeup --codeup-token=xxx --codeup-org=123 --codeup-repo=456
```

## Workflow

```
Codeup Issue → Agent implement → Review loop → Create MR → Merge → Close Issue → Comment
```

API authentication uses `PRIVATE-TOKEN` header against Codeup REST API v4.