### PR TITLE
feat: add Gitea and Linear issue source support

### DIFF
--- a/lib/gitea.sh
+++ b/lib/gitea.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# lib/gitea.sh — Gitea API helpers for autoresearch
+#
+# 环境变量:
+#   GITEA_URL    Gitea 实例地址，如 https://gitea.example.com (无尾斜杠)
+#   GITEA_TOKEN  Gitea 访问令牌 (Settings → Applications → Access Tokens)
+#
+# 用法:
+#   GITEA_URL=https://gitea.example.com GITEA_TOKEN=xxx \
+#     ./run.sh --issue-source=gitea -p /path/to/repo 42
+
+# ──────────────────────────────────────────────
+# 内部工具
+# ──────────────────────────────────────────────
+
+_gitea_api() {
+    local method="$1"; local path="$2"; shift 2
+    curl -sf -X "$method" \
+        -H "Authorization: token ${GITEA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "${GITEA_URL}/api/v1${path}" "$@"
+}
+
+# 从 git remote URL 提取 owner/repo
+# 支持 https://host/owner/repo.git 和 ssh://git@host/owner/repo.git
+_gitea_parse_remote() {
+    local remote_url="$1"
+    local path
+    path=$(echo "$remote_url" \
+        | sed -E \
+            -e 's|^https?://[^/]+/||' \
+            -e 's|^ssh://[^/@]+@?[^/]+/||' \
+            -e 's|^git@[^:]+:||' \
+            -e 's|\.git$||' \
+        | grep -oE '[^/]+/[^/]+$')
+    GITEA_OWNER=$(echo "$path" | cut -d'/' -f1)
+    GITEA_REPO=$(echo  "$path" | cut -d'/' -f2)
+}
+
+# ──────────────────────────────────────────────
+# Issue 获取
+# ──────────────────────────────────────────────
+
+get_gitea_issue_info() {
+    local issue_number="$1"
+
+    if [ -z "$GITEA_TOKEN" ]; then
+        error "GITEA_TOKEN 未设置，请先生成 Gitea Access Token"
+        exit 1
+    fi
+    if [ -z "$GITEA_URL" ]; then
+        error "GITEA_URL 未设置，请设置 Gitea 实例地址（如 https://gitea.example.com）"
+        exit 1
+    fi
+
+    local remote_url
+    remote_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
+    _gitea_parse_remote "$remote_url"
+
+    log "Gitea: ${GITEA_URL}/${GITEA_OWNER}/${GITEA_REPO} issue #${issue_number}"
+
+    local issue_json
+    issue_json=$(_gitea_api GET "/repos/${GITEA_OWNER}/${GITEA_REPO}/issues/${issue_number}" 2>&1)
+    if [ $? -ne 0 ] || [ -z "$issue_json" ]; then
+        error "无法获取 Gitea Issue #${issue_number}: ${issue_json}"
+        exit 1
+    fi
+
+    ISSUE_TITLE=$(echo "$issue_json" | jq -r '.title')
+    ISSUE_BODY=$(echo  "$issue_json" | jq -r '.body // ""')
+    ISSUE_STATE=$(echo "$issue_json" | jq -r '.state')
+    ISSUE_LABELS=$(echo "$issue_json" | jq -r '.labels[]?.name // empty' | tr '\n' ',' | sed 's/,$//')
+    ISSUE_FILE=""
+
+    if [ "$ISSUE_STATE" != "open" ]; then
+        error "Gitea Issue #${issue_number} 状态为 ${ISSUE_STATE}，不是 open"
+        exit 1
+    fi
+
+    log "Issue 标题: $ISSUE_TITLE"
+    log "Issue 标签: ${ISSUE_LABELS:-无}"
+}
+
+# ──────────────────────────────────────────────
+# PR 创建 + 合并
+# ──────────────────────────────────────────────
+
+gitea_create_and_merge_pr() {
+    local issue_number="$1"
+    local issue_title="$2"
+    local branch_name="$3"
+    local final_score="$4"
+    local iteration="$5"
+    local pr_body="$6"
+
+    local main_branch
+    main_branch=$(git -C "$PROJECT_ROOT" remote show origin 2>/dev/null \
+        | grep 'HEAD branch' | cut -d':' -f2 | tr -d ' ')
+    [ -z "$main_branch" ] && main_branch="master"
+
+    log_console "创建 Gitea Pull Request..."
+
+    local pr_json
+    pr_json=$(_gitea_api POST \
+        "/repos/${GITEA_OWNER}/${GITEA_REPO}/pulls" \
+        -d "$(jq -n \
+            --arg title "feat: ${issue_title} (#${issue_number})" \
+            --arg body  "$pr_body" \
+            --arg head  "$branch_name" \
+            --arg base  "$main_branch" \
+            '{title:$title, body:$body, head:$head, base:$base}')" 2>&1)
+
+    if [ $? -ne 0 ] || [ -z "$pr_json" ]; then
+        log_console "⚠️ Gitea PR 创建失败: $pr_json"
+        return 1
+    fi
+
+    local pr_number pr_url
+    pr_number=$(echo "$pr_json" | jq -r '.number')
+    pr_url=$(echo     "$pr_json" | jq -r '.html_url')
+    log_console "✅ PR 已创建: $pr_url"
+    set_phase "create_pr"
+
+    # 合并 PR
+    log_console "合并 PR #${pr_number}..."
+    local merge_resp
+    merge_resp=$(_gitea_api POST \
+        "/repos/${GITEA_OWNER}/${GITEA_REPO}/pulls/${pr_number}/merge" \
+        -d '{"Do":"merge","merge_message_field":"Auto-merged by autoresearch"}' 2>&1)
+
+    if [ $? -ne 0 ]; then
+        log_console "⚠️ PR 合并失败，请手动处理: $pr_url"
+        log "PR merge failed: $merge_resp"
+    else
+        log_console "✅ PR #${pr_number} 已合并"
+    fi
+
+    PR_URL="$pr_url"
+    PR_NUMBER="$pr_number"
+}
+
+# ──────────────────────────────────────────────
+# Issue 评论 + 关闭
+# ──────────────────────────────────────────────
+
+gitea_comment_issue() {
+    local issue_number="$1"
+    local body="$2"
+
+    _gitea_api POST \
+        "/repos/${GITEA_OWNER}/${GITEA_REPO}/issues/${issue_number}/comments" \
+        -d "$(jq -n --arg body "$body" '{body:$body}')" > /dev/null 2>&1 \
+        || log "警告: Gitea 添加评论失败"
+}
+
+gitea_close_issue() {
+    local issue_number="$1"
+
+    _gitea_api PATCH \
+        "/repos/${GITEA_OWNER}/${GITEA_REPO}/issues/${issue_number}" \
+        -d '{"state":"closed"}' > /dev/null 2>&1 \
+        || log_console "⚠️ 关闭 Gitea Issue 失败 (可能已通过 PR 自动关闭)"
+}
+
+# ──────────────────────────────────────────────
+# 自动检测 remote 是否为 Gitea
+# ──────────────────────────────────────────────
+
+is_gitea_remote() {
+    local remote_url="$1"
+    if [ -z "$GITEA_URL" ]; then
+        return 1
+    fi
+    local gitea_host
+    gitea_host=$(echo "$GITEA_URL" | sed -E 's|^https?://||')
+    echo "$remote_url" | grep -q "$gitea_host"
+}

--- a/lib/linear.sh
+++ b/lib/linear.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# lib/linear.sh — Linear API helpers for autoresearch
+#
+# 环境变量:
+#   LINEAR_API_KEY  Linear Personal API Key (Settings → API → Personal API keys)
+#
+# Linear identifier 格式: TEAM-NUMBER (如 OMC-57, XAR-407)
+# 全局变量 (由 get_linear_issue_info 设置):
+#   LINEAR_ISSUE_ID   Linear 内部 UUID（用于后续 mutation）
+#   LINEAR_TEAM_KEY   从 identifier 提取的 team key（如 OMC）
+
+LINEAR_ISSUE_ID=""
+LINEAR_TEAM_KEY=""
+
+# ──────────────────────────────────────────────
+# 内部工具
+# ──────────────────────────────────────────────
+
+_linear_gql() {
+    local query="$1"
+    local variables="${2:-{\}}"
+    curl -sf \
+        -H "Authorization: ${LINEAR_API_KEY}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg q "$query" --argjson v "$variables" '{query:$q,variables:$v}')" \
+        "https://api.linear.app/graphql"
+}
+
+# ──────────────────────────────────────────────
+# Issue 获取
+# ──────────────────────────────────────────────
+
+get_linear_issue_info() {
+    local identifier="$1"
+
+    if [ -z "$LINEAR_API_KEY" ]; then
+        error "LINEAR_API_KEY 未设置，请先生成 Linear Personal API Key"
+        exit 1
+    fi
+
+    # 提取 team key（OMC-57 → OMC）
+    LINEAR_TEAM_KEY=$(echo "$identifier" | cut -d'-' -f1)
+
+    log "Linear: 获取 Issue ${identifier}..."
+
+    local query='query GetIssue($id: String!) {
+  issues(filter: { identifier: { eq: $id } }) {
+    nodes {
+      id identifier title description
+      state { name type }
+      labels { nodes { name } }
+    }
+  }
+}'
+    local vars
+    vars=$(jq -n --arg id "$identifier" '{id: $id}')
+
+    local resp
+    resp=$(_linear_gql "$query" "$vars" 2>&1)
+    if [ $? -ne 0 ] || [ -z "$resp" ]; then
+        error "无法连接 Linear API: $resp"
+        exit 1
+    fi
+
+    local node
+    node=$(echo "$resp" | jq -r '.data.issues.nodes[0] // empty')
+    if [ -z "$node" ]; then
+        error "找不到 Linear Issue: $identifier"
+        exit 1
+    fi
+
+    LINEAR_ISSUE_ID=$(echo "$node" | jq -r '.id')
+    ISSUE_TITLE=$(echo "$node" | jq -r '.title')
+    ISSUE_BODY=$(echo "$node" | jq -r '.description // ""')
+    ISSUE_STATE=$(echo "$node" | jq -r '.state.type')   # backlog/unstarted/started/completed/cancelled
+    ISSUE_LABELS=$(echo "$node" | jq -r '.labels.nodes[].name' | tr '\n' ',' | sed 's/,$//')
+    ISSUE_FILE=""
+
+    if [ "$ISSUE_STATE" = "completed" ] || [ "$ISSUE_STATE" = "cancelled" ]; then
+        error "Linear Issue ${identifier} 状态为 ${ISSUE_STATE}，跳过"
+        exit 1
+    fi
+
+    log "Issue 标题: $ISSUE_TITLE"
+    log "Issue 标签: ${ISSUE_LABELS:-无}"
+}
+
+# ──────────────────────────────────────────────
+# 添加评论
+# ──────────────────────────────────────────────
+
+linear_comment_issue() {
+    local issue_id="$1"
+    local body="$2"
+
+    local mutation='mutation AddComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) { success }
+}'
+    local vars
+    vars=$(jq -n --arg issueId "$issue_id" --arg body "$body" \
+        '{issueId: $issueId, body: $body}')
+
+    _linear_gql "$mutation" "$vars" > /dev/null 2>&1 \
+        || log "警告: Linear 添加评论失败"
+}
+
+# ──────────────────────────────────────────────
+# 更新 Issue 状态
+# 查找 team 下名为 $state_name 的 WorkflowState，然后执行 issueUpdate
+# ──────────────────────────────────────────────
+
+linear_update_state() {
+    local issue_id="$1"
+    local team_key="$2"
+    local state_name="$3"
+
+    # 查 stateId
+    local sq='query States($key: String!) {
+  teams(filter: { key: { eq: $key } }) {
+    nodes { states { nodes { id name } } }
+  }
+}'
+    local sv
+    sv=$(jq -n --arg key "$team_key" '{key: $key}')
+    local state_resp
+    state_resp=$(_linear_gql "$sq" "$sv" 2>/dev/null)
+
+    local state_id
+    state_id=$(echo "$state_resp" | jq -r \
+        --arg name "$state_name" \
+        '.data.teams.nodes[0].states.nodes[]? | select(.name==$name) | .id' \
+        2>/dev/null | head -1)
+
+    if [ -z "$state_id" ] || [ "$state_id" = "null" ]; then
+        log "警告: 找不到 Linear 状态 '${state_name}'（team: ${team_key}），跳过状态更新"
+        return 0
+    fi
+
+    local mutation='mutation UpdateIssue($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) { success }
+}'
+    local vars
+    vars=$(jq -n --arg id "$issue_id" --arg stateId "$state_id" \
+        '{id: $id, stateId: $stateId}')
+
+    _linear_gql "$mutation" "$vars" > /dev/null 2>&1 \
+        || log "警告: Linear 更新状态失败"
+}

--- a/run.sh
+++ b/run.sh
@@ -151,7 +151,7 @@ CODEUP_TARGET_BRANCH="${CODEUP_TARGET_BRANCH:-}"
 ICODE_REPO=""
 
 # 共享库：核心逻辑
-for _lib in scoring context progress subtask prompt ui_verify; do
+for _lib in scoring context progress subtask prompt ui_verify gitea linear; do
     _lib_path="$SCRIPT_DIR/lib/${_lib}.sh"
     if [ ! -f "$_lib_path" ]; then
         echo "ERROR: 缺少库文件: $_lib_path" >&2
@@ -858,7 +858,7 @@ usage() {
     echo "  --no-ui-verify   禁用 UI 验证 (默认启用)"
     echo "  --no-hard-gate   禁用硬门禁检查 (build/lint/test 预检, 默认启用)"
     echo "  --issues-dir=<path>  本地 Issue 目录 (启用本地模式，不使用 GitHub)"
-    echo "  --issue-source=<mode>  Issue 来源: github (默认) | local | baidu | codeup | icode"
+    echo "  --issue-source=<mode>  Issue 来源: github (默认) | gitea | linear | local | baidu | codeup | icode"
     echo "  --space=<prefixCode>   iCafe 空间前缀代码 (baidu 模式必需，也可用 ICAFE_SPACE 环境变量)"
     echo "  --target-branch=<name> iCode CR 目标分支 (默认: 自动检测远程 HEAD 分支，回退到 master)"
     echo "  --codeup-ak-id=<ak_id>   阿里云 Access Key ID (codeup 模式必需，也可用 CODEUP_AK_ID 环境变量)"
@@ -963,7 +963,7 @@ check_project() {
     fi
 
     # 拉取 autoresearch 最新代码（continue 模式、本地模式、百度模式、codeup 模式和 icode 模式跳过，避免冲突）
-    if [ $CONTINUE_MODE -eq 0 ] && [ "$ISSUE_SOURCE" != "local" ] && [ "$ISSUE_SOURCE" != "baidu" ] && [ "$ISSUE_SOURCE" != "codeup" ] && [ "$ISSUE_SOURCE" != "icode" ]; then
+    if [ $CONTINUE_MODE -eq 0 ] && [ "$ISSUE_SOURCE" != "local" ] && [ "$ISSUE_SOURCE" != "baidu" ] && [ "$ISSUE_SOURCE" != "codeup" ] && [ "$ISSUE_SOURCE" != "icode" ] && [ "$ISSUE_SOURCE" != "gitea" ] && [ "$ISSUE_SOURCE" != "linear" ]; then
         local autoresearch_dir
         autoresearch_dir="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel 2>/dev/null || true)"
         if [ -n "$autoresearch_dir" ] && git -C "$autoresearch_dir" rev-parse --is-inside-work-tree &> /dev/null; then
@@ -1099,6 +1099,27 @@ check_dependencies() {
 
 # 检测 Issue 来源模式 (在 check_project 之前调用)
 detect_issue_source_mode() {
+    # 如果显式指定 linear 模式
+    if [ "$ISSUE_SOURCE" = "linear" ]; then
+        if [ -z "$LINEAR_API_KEY" ]; then
+            error "linear 模式需要设置 LINEAR_API_KEY 环境变量"
+            exit 1
+        fi
+        log "Linear 模式 (Issue: $ISSUE_NUMBER)"
+        return 0
+    fi
+
+    # 自动检测 Gitea 模式: git remote 包含 Gitea 实例地址 (GITEA_URL)
+    if [ "$ISSUE_SOURCE" = "github" ] && [ -n "$GITEA_URL" ]; then
+        local remote_url
+        remote_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
+        if is_gitea_remote "$remote_url"; then
+            ISSUE_SOURCE="gitea"
+            log "Gitea 模式 (自动检测: remote 匹配 ${GITEA_URL})"
+            return 0
+        fi
+    fi
+
     # 如果显式指定 baidu 模式
     if [ "$ISSUE_SOURCE" = "baidu" ]; then
         if [ -z "$ICAFE_SPACE" ]; then
@@ -1432,6 +1453,18 @@ get_issue_info() {
     local issue_number=$1
 
     log "获取 Issue #$issue_number 信息..."
+
+    # Linear 模式
+    if [ "$ISSUE_SOURCE" = "linear" ]; then
+        get_linear_issue_info "$issue_number"
+        return 0
+    fi
+
+    # Gitea 模式
+    if [ "$ISSUE_SOURCE" = "gitea" ]; then
+        get_gitea_issue_info "$issue_number"
+        return 0
+    fi
 
     # 百度 iCafe 模式
     if [ "$ISSUE_SOURCE" = "baidu" ]; then
@@ -4289,7 +4322,7 @@ $(jq -r '.subtasks[] | "- [\(.passes | if true then "x" else " " end)] \(.id): \
 "
     fi
 
-    PR_URL=$(gh pr create --title "feat: $ISSUE_TITLE (#$ISSUE_NUMBER)" --body "$(cat <<EOF
+    _pr_body="$(cat <<EOF
 ## Summary
 - Implements #$ISSUE_NUMBER
 - Score: $FINAL_SCORE/100
@@ -4301,21 +4334,126 @@ $subtask_summary$ui_verify_summary
 
 Closes #$ISSUE_NUMBER
 EOF
-)" 2>&1)
+)"
+    _log_summary=""
+    [ -f "$WORK_DIR/log.md" ] && _log_summary=$(cat "$WORK_DIR/log.md")
 
-    if echo "$PR_URL" | grep -q "https://github.com"; then
-        PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-        log_console "✅ PR 已创建: $PR_URL"
-        set_phase "create_pr"
+    _finish_github_pr() {
+        # 切换回主分支
+        cd "$PROJECT_ROOT"
+        local mb
+        mb=$(git remote show origin | grep 'HEAD branch' | cut -d':' -f2 | tr -d ' ')
+        [ -z "$mb" ] && mb="master"
+        local stashed=0
+        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+            log "检测到未提交的更改，暂存..."
+            git stash push -m "autoresearch-temp-$(date +%s)" -- .autoresearch/ 2>/dev/null && stashed=1
+        fi
+        cleanup_merged_branch "$mb" "$BRANCH_NAME"
+        [ $stashed -eq 1 ] && { git stash pop 2>/dev/null || git stash drop 2>/dev/null || true; }
+    }
 
-        # 合并 PR（不删除本地分支，我们自己处理）
-        log_console "合并 PR #$PR_NUMBER..."
-        MERGE_OUTPUT=""
-        if ! MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --merge 2>&1); then
-            log_console "⚠️ PR 合并失败，请手动处理"
-            log_console "PR URL: $PR_URL"
-            log "PR merge failed: $MERGE_OUTPUT"
-            cat >> "$WORK_DIR/log.md" << EOF
+    if [ "$ISSUE_SOURCE" = "gitea" ]; then
+        # ── Gitea PR 创建 + 合并 ──────────────────────────────────
+        if gitea_create_and_merge_pr \
+                "$ISSUE_NUMBER" "$ISSUE_TITLE" "$BRANCH_NAME" \
+                "$FINAL_SCORE" "$ITERATION" "$_pr_body"; then
+            _finish_github_pr
+            log_console "添加评论到 Gitea Issue #$ISSUE_NUMBER..."
+            gitea_comment_issue "$ISSUE_NUMBER" "$(cat <<EOF
+## 自动处理完成
+
+- **PR**: ${PR_URL:-N/A} (已合并)
+- **评分**: $FINAL_SCORE/100
+- **迭代次数**: $ITERATION
+- **实现方式**: autoresearch 多 agent 迭代 (${AGENT_NAMES[*]})
+
+${_log_summary}
+
+该 Issue 已由 autoresearch 自动实现、审核并合并。
+EOF
+)"
+            log_console "关闭 Gitea Issue #$ISSUE_NUMBER..."
+            gitea_close_issue "$ISSUE_NUMBER"
+            log_console ""
+            log_console "  ╔══════════════════════════════════════╗"
+            log_console "  ║      全部完成！Issue 已自动处理      ║"
+            log_console "  ╚══════════════════════════════════════╝"
+            log_console ""
+            log_console "✅ PR: ${PR_URL:-N/A}"
+            log_console "🔗 状态: 已合并并关闭"
+        else
+            log_console "⚠️ Gitea PR 创建失败"
+        fi
+
+    elif [ "$ISSUE_SOURCE" = "linear" ]; then
+        # ── Linear: PR 打到底层 git host，然后更新 Linear ticket ──
+        _linear_remote=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
+        _linear_ok=0
+        if is_gitea_remote "$_linear_remote"; then
+            gitea_create_and_merge_pr \
+                "$ISSUE_NUMBER" "$ISSUE_TITLE" "$BRANCH_NAME" \
+                "$FINAL_SCORE" "$ITERATION" "$_pr_body" && _linear_ok=1
+        else
+            _gh_out=$(gh pr create \
+                --title "feat: ${ISSUE_TITLE} (${ISSUE_NUMBER})" \
+                --body "$_pr_body" 2>&1)
+            if echo "$_gh_out" | grep -q "https://github.com"; then
+                PR_URL="$_gh_out"
+                PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+                log_console "✅ PR 已创建: $PR_URL"
+                set_phase "create_pr"
+                gh pr merge "$PR_NUMBER" --merge 2>/dev/null \
+                    && log_console "✅ PR #${PR_NUMBER} 已合并" \
+                    || log_console "⚠️ PR 合并失败，请手动处理: $PR_URL"
+                _linear_ok=1
+            fi
+        fi
+        if [ "$_linear_ok" -eq 1 ]; then
+            _finish_github_pr
+            log_console "更新 Linear ticket ${ISSUE_NUMBER}..."
+            linear_comment_issue "$LINEAR_ISSUE_ID" "$(cat <<EOF
+## autoresearch 完成
+
+- **PR**: ${PR_URL:-N/A} (已合并)
+- **评分**: $FINAL_SCORE/100
+- **迭代次数**: $ITERATION
+- **agents**: ${AGENT_NAMES[*]}
+
+${_log_summary}
+EOF
+)"
+            linear_update_state "$LINEAR_ISSUE_ID" "$LINEAR_TEAM_KEY" "In Review"
+            log_console "✅ Linear ${ISSUE_NUMBER} 已移入 In Review"
+            log_console ""
+            log_console "  ╔══════════════════════════════════════╗"
+            log_console "  ║      全部完成！Issue 已自动处理      ║"
+            log_console "  ╚══════════════════════════════════════╝"
+            log_console ""
+            log_console "✅ PR: ${PR_URL:-N/A}"
+            log_console "🔗 Linear: ${ISSUE_NUMBER} -> In Review"
+        else
+            log_console "⚠️ PR 创建失败，Linear ticket 未更新"
+        fi
+        unset _linear_remote _linear_ok _gh_out
+
+    else
+        # ── GitHub PR 创建 + 合并 ─────────────────────────────────
+        PR_URL=$(gh pr create --title "feat: $ISSUE_TITLE (#$ISSUE_NUMBER)" \
+            --body "$_pr_body" 2>&1)
+
+        if echo "$PR_URL" | grep -q "https://github.com"; then
+            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+            log_console "✅ PR 已创建: $PR_URL"
+            set_phase "create_pr"
+
+            log_console "合并 PR #$PR_NUMBER..."
+            MERGE_OUTPUT=""
+            if ! MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --merge 2>&1); then
+                log_console "⚠️ PR 合并失败，请手动处理"
+                log_console "PR URL: $PR_URL"
+                log "PR merge failed: $MERGE_OUTPUT"
+                cat >> "$WORK_DIR/log.md" << EOF
 
 ---
 
@@ -4330,67 +4468,42 @@ $MERGE_OUTPUT
 
 请手动合并: gh pr merge $PR_NUMBER --merge
 EOF
-        fi
-
-        # 切换回主分支前，先处理未提交的更改
-        cd "$PROJECT_ROOT"
-        main_branch=$(git remote show origin | grep 'HEAD branch' | cut -d':' -f2 | tr -d ' ')
-        [ -z "$main_branch" ] && main_branch="master"
-
-        # 切换回主分支前，如果有未提交的更改，先 stash
-        stashed=0
-        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-            log "检测到未提交的更改，暂存..."
-            if git stash push -m "autoresearch-temp-$(date +%s)" -- .autoresearch/ 2>/dev/null; then
-                stashed=1
             fi
-        fi
 
-        cleanup_merged_branch "$main_branch" "$BRANCH_NAME"
+            _finish_github_pr
 
-        # 恢复 stash（.autoresearch/ 为临时数据，恢复失败直接 drop）
-        if [ $stashed -eq 1 ]; then
-            if ! git stash pop 2>/dev/null; then
-                log "stash pop 失败（文件冲突），跳过恢复"
-                git stash drop 2>/dev/null || true
-            fi
-        fi
-
-        # 添加评论到 Issue（仅包含总结信息）
-        log_console "添加评论到 Issue #$ISSUE_NUMBER..."
-        log_summary=""
-        if [ -f "$WORK_DIR/log.md" ]; then
-            log_summary=$(cat "$WORK_DIR/log.md")
-        fi
-        gh issue comment "$ISSUE_NUMBER" --body "$(cat <<EOF
+            log_console "添加评论到 Issue #$ISSUE_NUMBER..."
+            gh issue comment "$ISSUE_NUMBER" --body "$(cat <<EOF
 ## 自动处理完成
 
 - **PR**: $PR_URL (已合并)
 - **评分**: $FINAL_SCORE/100
 - **迭代次数**: $ITERATION
-- **实现方式**: autoresearch 多 agent 迭代 (${AGENT_NAMES[@]})
+- **实现方式**: autoresearch 多 agent 迭代 (${AGENT_NAMES[*]})
 
-${log_summary}
+${_log_summary}
 
 该 Issue 已由 autoresearch 自动实现、审核并合并。
 EOF
 )" 2>/dev/null || log "警告: 添加评论失败"
 
-        # 关闭 Issue
-        log_console "关闭 Issue #$ISSUE_NUMBER..."
-        gh issue close "$ISSUE_NUMBER" --reason completed 2>/dev/null || log_console "⚠️ 关闭 Issue 失败 (可能已通过 PR 自动关闭)"
+            log_console "关闭 Issue #$ISSUE_NUMBER..."
+            gh issue close "$ISSUE_NUMBER" --reason completed 2>/dev/null \
+                || log_console "⚠️ 关闭 Issue 失败 (可能已通过 PR 自动关闭)"
 
-        log_console ""
-        log_console "  ╔══════════════════════════════════════╗"
-        log_console "  ║      全部完成！Issue 已自动处理      ║"
-        log_console "  ╚══════════════════════════════════════╝"
-        log_console ""
-        log_console "✅ PR: $PR_URL"
-        log_console "🔗 状态: 已合并并关闭"
-    else
-        log_console "⚠️ PR 创建失败或已存在"
-        log_console "$PR_URL"
+            log_console ""
+            log_console "  ╔══════════════════════════════════════╗"
+            log_console "  ║      全部完成！Issue 已自动处理      ║"
+            log_console "  ╚══════════════════════════════════════╝"
+            log_console ""
+            log_console "✅ PR: $PR_URL"
+            log_console "🔗 状态: 已合并并关闭"
+        else
+            log_console "⚠️ PR 创建失败或已存在"
+            log_console "$PR_URL"
+        fi
     fi
+    unset _pr_body _log_summary
 
     SCRIPT_COMPLETED_NORMALLY=1
     exit 0


### PR DESCRIPTION
## What

Adds two new `--issue-source` modes:

- `gitea` - self-hosted Gitea instances (REST API)
- `linear` - Linear project management (GraphQL API)

## New files

- `lib/gitea.sh` - Gitea REST API helpers (issue fetch, PR create/merge, comment/close, remote auto-detect via `GITEA_URL`)
- `lib/linear.sh` - Linear GraphQL API helpers (issue fetch by identifier like `OMC-57`, comment, state transition to In Review)

## Usage

```bash
# Gitea
GITEA_URL=https://gitea.example.com GITEA_TOKEN=xxx ./run.sh --issue-source=gitea -p /repo 42

# Linear
LINEAR_API_KEY=xxx ./run.sh --issue-source=linear -p /repo OMC-57
```n
## Notes

- GitHub path unchanged
- No hardcoded instance URLs - GITEA_URL must be set explicitly
- Gitea auto-detected when GITEA_URL matches repo remote
- Linear moves ticket to In Review after merge; does not auto-close (team workflows vary)